### PR TITLE
fix: proxy should listen on port 8080 by default

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -85,6 +85,6 @@ func main() {
 
 	// start the balls rolling
 	openwhisk.Debug("OpenWhisk ActionLoop Proxy %s: starting", openwhisk.Version)
-	ap.Start(8082)
+	ap.Start(8080)
 
 }


### PR DESCRIPTION
fix: proxy should listen on port 8080 by default