### PR TITLE
Cleanup remote actions

### DIFF
--- a/openwhisk/actionProxy.go
+++ b/openwhisk/actionProxy.go
@@ -56,8 +56,8 @@ type ActionProxy struct {
 	proxyMode ProxyMode
 	// client proxy data, if runtime is a forwarder
 	clientProxyData *ClientProxyData
-	// ServerProxyData, if runtime is a server
-	ServerProxyData *ServerProxyData
+	// serverProxyData, if runtime is a server
+	serverProxyData *ServerProxyData
 
 	// is it initialized?
 	initialized bool
@@ -201,6 +201,8 @@ func (ap *ActionProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ap.initHandler(w, r)
 	case "/run":
 		ap.runHandler(w, r)
+	case "/stop":
+		ap.stopHandler(w, r)
 	}
 }
 

--- a/openwhisk/forward_proxy.go
+++ b/openwhisk/forward_proxy.go
@@ -66,7 +66,6 @@ func (ap *ActionProxy) ForwardRunRequest(w http.ResponseWriter, r *http.Request)
 		req.URL.Scheme = ap.clientProxyData.ProxyURL.Scheme
 		req.URL.Host = ap.clientProxyData.ProxyURL.Host
 
-		Debug("Forwarding action with id %s to %s", ap.clientProxyData.ProxyActionID, ap.clientProxyData.ProxyURL.String())
 	}
 
 	proxy := &httputil.ReverseProxy{Director: director}
@@ -124,8 +123,6 @@ func (ap *ActionProxy) ForwardInitRequest(w http.ResponseWriter, r *http.Request
 
 		req.URL.Scheme = ap.clientProxyData.ProxyURL.Scheme
 		req.URL.Host = ap.clientProxyData.ProxyURL.Host
-
-		Debug("Forwarding action with id %s to %s", ap.clientProxyData.ProxyActionID, ap.clientProxyData.ProxyURL.String())
 	}
 
 	proxy := &httputil.ReverseProxy{Director: director}

--- a/openwhisk/initHandler.go
+++ b/openwhisk/initHandler.go
@@ -66,8 +66,8 @@ func (ap *ActionProxy) initHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if ap.proxyMode == ProxyModeServer {
-		if ap.ServerProxyData == nil {
-			ap.ServerProxyData = &ServerProxyData{actions: make(map[string]*ActionProxy)}
+		if ap.serverProxyData == nil {
+			ap.serverProxyData = &ServerProxyData{actions: make(map[string]*ActionProxy)}
 		}
 
 		innerActionProxy := NewActionProxy(ap.baseDir, ap.compiler, ap.outFile, ap.errFile, ProxyModeNone)
@@ -80,7 +80,7 @@ func (ap *ActionProxy) initHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		ap.ServerProxyData.actions[id] = innerActionProxy
+		ap.serverProxyData.actions[id] = innerActionProxy
 		Debug("Added action %s to the server proxy data", id)
 
 		sendOK(w)

--- a/openwhisk/runHandler.go
+++ b/openwhisk/runHandler.go
@@ -72,7 +72,7 @@ func (ap *ActionProxy) runHandler(w http.ResponseWriter, r *http.Request) {
 
 		actionID := runRequest.ProxiedActionID
 
-		innerActionProxy, ok := ap.ServerProxyData.actions[actionID]
+		innerActionProxy, ok := ap.serverProxyData.actions[actionID]
 		if !ok {
 			Debug("Action %s not found in server proxy data", actionID)
 			sendError(w, http.StatusNotFound, "Action not found in remote runtime. Check logs for details.")

--- a/openwhisk/stopHandler.go
+++ b/openwhisk/stopHandler.go
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openwhisk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+type stopRequest struct {
+	ProxiedActionID string `json:"proxiedActionID,omitempty"`
+}
+
+func (ap *ActionProxy) stopHandler(w http.ResponseWriter, r *http.Request) {
+	if ap.proxyMode != ProxyModeServer {
+		sendError(w, http.StatusUnprocessableEntity, "Stop is only supported in server mode")
+		return
+	}
+
+	// parse the request
+	body, err := io.ReadAll(r.Body)
+	defer r.Body.Close()
+	if err != nil {
+		sendError(w, http.StatusBadRequest, fmt.Sprintf("Error reading request body: %v", err))
+		return
+	}
+
+	var stopRequest stopRequest
+	err = json.NewDecoder(bytes.NewReader(body)).Decode(&stopRequest)
+	if err != nil {
+		sendError(w, http.StatusBadRequest, fmt.Sprintf("Error decoding run body: %v", err))
+		return
+	}
+
+	actionID := stopRequest.ProxiedActionID
+
+	innerAP, ok := ap.serverProxyData.actions[actionID]
+	if !ok {
+		Debug("Action '%s' not found in server proxy data", actionID)
+		sendError(w, http.StatusNotFound, "Action to be removed in remote runtime not found. Check logs for details.")
+	}
+
+	innerAP.theExecutor.Stop()
+	Debug("Action '%s' executor stopped", actionID)
+	if err := os.RemoveAll(filepath.Join(innerAP.baseDir, strconv.Itoa(innerAP.currentDir))); err != nil {
+		Debug("Error removing action directory: %v", err)
+	}
+
+	delete(ap.serverProxyData.actions, actionID)
+
+	sendOK(w)
+}

--- a/openwhisk/stopHandler_test.go
+++ b/openwhisk/stopHandler_test.go
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openwhisk
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopHandler(t *testing.T) {
+
+	actionID := "test-action-id"
+	// temporary workdir
+	dir, _ := os.MkdirTemp("", "action")
+	file, _ := filepath.Abs("_test")
+	os.Symlink(file, dir+"/_test")
+	os.Chdir(dir)
+	// setup the server
+	buf, _ := os.CreateTemp("", "log")
+	rootAP := NewActionProxy(dir, "", buf, buf, ProxyModeServer)
+	rootAP.serverProxyData = &ServerProxyData{
+		actions: make(map[string]*ActionProxy),
+	}
+
+	ts := httptest.NewServer(rootAP)
+
+	dat, _ := os.ReadFile("_test/hello_message")
+	enc := base64.StdEncoding.EncodeToString(dat)
+	body := initBodyRequest{Binary: true, Code: enc}
+	initBody, _ := json.Marshal(initRequest{Value: body, ProxiedActionID: actionID})
+	doInit(ts, string(initBody))
+	require.Contains(t, rootAP.serverProxyData.actions, actionID)
+	lastAction := highestDir(dir)
+	fmt.Printf("lastAction dir: %d\n", lastAction)
+
+	doRun(ts, "")
+	doStop(ts, actionID)
+
+	require.NotContains(t, rootAP.serverProxyData.actions, actionID)
+	require.NoDirExistsf(t, filepath.Join(dir, strconv.Itoa(lastAction)), "lastAction dir should be removed")
+
+}

--- a/openwhisk/stopHandler_test.go
+++ b/openwhisk/stopHandler_test.go
@@ -20,7 +20,6 @@ package openwhisk
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -54,7 +53,6 @@ func TestStopHandler(t *testing.T) {
 	doInit(ts, string(initBody))
 	require.Contains(t, rootAP.serverProxyData.actions, actionID)
 	lastAction := highestDir(dir)
-	fmt.Printf("lastAction dir: %d\n", lastAction)
 
 	doRun(ts, "")
 	doStop(ts, actionID)

--- a/openwhisk/stopper.go
+++ b/openwhisk/stopper.go
@@ -29,7 +29,13 @@ import (
 	"syscall"
 )
 
-func (ap *ActionProxy) HookExitSignals(captureSignalChan chan os.Signal) {
+func (ap *ActionProxy) HookExitSignals() {
+	signalChan := make(chan os.Signal, 1)
+	listenOnExitSignals(ap, signalChan)
+	os.Exit(0)
+}
+
+func listenOnExitSignals(ap *ActionProxy, captureSignalChan chan os.Signal) {
 	// Relay stop signals to captureSignalChan
 	signal.Notify(captureSignalChan,
 		syscall.SIGINT,
@@ -41,7 +47,6 @@ func (ap *ActionProxy) HookExitSignals(captureSignalChan chan os.Signal) {
 
 	Debug("Listening on exit signals for remote action cleanup...")
 	signalHandler(<-captureSignalChan, ap)
-
 }
 
 func signalHandler(signal os.Signal, ap *ActionProxy) {

--- a/openwhisk/stopper.go
+++ b/openwhisk/stopper.go
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openwhisk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+)
+
+func (ap *ActionProxy) HookExitSignals(captureSignalChan chan os.Signal) {
+	// Relay stop signals to captureSignalChan
+	signal.Notify(captureSignalChan,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGABRT,
+		syscall.SIGQUIT,
+		syscall.SIGHUP)
+	defer signal.Stop(captureSignalChan)
+
+	Debug("Listening on exit signals for remote action cleanup...")
+	signalHandler(<-captureSignalChan, ap)
+
+}
+
+func signalHandler(signal os.Signal, ap *ActionProxy) {
+	Debug("Caught signal: %v", signal)
+
+	_ = ap.SendStopRequest()
+
+	Debug("Finished remote action cleanup. Exiting.")
+}
+
+func (ap *ActionProxy) SendStopRequest() error {
+	if ap.clientProxyData == nil {
+		Debug("Nothing to stop")
+		return fmt.Errorf("runtime not set as client")
+	}
+
+	stopRequest := stopRequest{
+		ProxiedActionID: ap.clientProxyData.ProxyActionID,
+	}
+
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(stopRequest)
+	if err != nil {
+		Debug("Failed to send stop request: error encoding stop request body: %v", err)
+		return err
+	}
+
+	bodyLen := buf.Len()
+
+	body := io.NopCloser(bytes.NewBuffer(buf.Bytes()))
+	url := ap.clientProxyData.ProxyURL.String() + "/stop"
+	req, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		Debug("Failed to send stop request: error creating stop request: %v", err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", strconv.Itoa(bodyLen))
+	req.ContentLength = int64(bodyLen)
+
+	client := &http.Client{}
+
+	Debug("Sending stop request to %s", url)
+	resp, err := client.Do(req)
+	if err != nil {
+		Debug("Failed to send stop request: %v", err)
+		return err
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+
+	Debug("Stop request response: %v", string(respBody))
+	return nil
+}

--- a/openwhisk/stopper_test.go
+++ b/openwhisk/stopper_test.go
@@ -57,7 +57,7 @@ func TestSendStopRequest(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
-func TestHookExitSignals(t *testing.T) {
+func TestListenOnExitSignals(t *testing.T) {
 	mockedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var stopReq stopRequest
 		err := json.NewDecoder(r.Body).Decode(&stopReq)
@@ -76,5 +76,5 @@ func TestHookExitSignals(t *testing.T) {
 
 	signalChan := make(chan os.Signal, 1)
 	signalChan <- os.Interrupt
-	ap.HookExitSignals(signalChan)
+	listenOnExitSignals(ap, signalChan)
 }

--- a/openwhisk/stopper_test.go
+++ b/openwhisk/stopper_test.go
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openwhisk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendStopRequest(t *testing.T) {
+
+	t.Run("clientProxyData is nil", func(t *testing.T) {
+		ap := &ActionProxy{}
+		err := ap.SendStopRequest()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "runtime not set as client")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		mockedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var stopReq stopRequest
+			err := json.NewDecoder(r.Body).Decode(&stopReq)
+			require.NoError(t, err)
+			require.Equal(t, "test-action-id", stopReq.ProxiedActionID)
+		}))
+
+		url, _ := url.Parse(mockedServer.URL)
+		ap := &ActionProxy{
+			clientProxyData: &ClientProxyData{
+				ProxyActionID: "test-action-id",
+				ProxyURL:      *url,
+			},
+		}
+
+		err := ap.SendStopRequest()
+		require.NoError(t, err)
+	})
+}
+func TestHookExitSignals(t *testing.T) {
+	mockedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var stopReq stopRequest
+		err := json.NewDecoder(r.Body).Decode(&stopReq)
+		require.NoError(t, err)
+		require.Equal(t, "test-action-id", stopReq.ProxiedActionID)
+	}))
+
+	url, _ := url.Parse(mockedServer.URL)
+
+	ap := &ActionProxy{
+		clientProxyData: &ClientProxyData{
+			ProxyActionID: "test-action-id",
+			ProxyURL:      *url,
+		},
+	}
+
+	signalChan := make(chan os.Signal, 1)
+	signalChan <- os.Interrupt
+	ap.HookExitSignals(signalChan)
+}

--- a/openwhisk/util_test.go
+++ b/openwhisk/util_test.go
@@ -100,6 +100,15 @@ func doInit(ts *httptest.Server, message string) {
 	}
 }
 
+func doStop(ts *httptest.Server, actionID string) {
+	resp, status, err := doPost(ts.URL+"/stop", fmt.Sprintf(`{"proxiedActionID":"%s"}`, actionID))
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Printf("%d %s", status, resp)
+	}
+}
+
 func initCode(file string, main string) string {
 	dat, _ := os.ReadFile(file)
 	body := initBodyRequest{Code: string(dat)}

--- a/proxy.go
+++ b/proxy.go
@@ -21,10 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 	"runtime"
-	"syscall"
-	"time"
 
 	"github.com/apache/openserverless-runtimes/openwhisk"
 )
@@ -86,54 +83,12 @@ func main() {
 		return
 	}
 
-	go hookExitSignals()
+	if useProxyClient == "1" {
+		// hook exit signals for remote action cleanup
+		go ap.HookExitSignals(make(chan os.Signal, 1))
+	}
 
 	// start the balls rolling
 	openwhisk.Debug("OpenWhisk ActionLoop Proxy %s: starting", openwhisk.Version)
 	ap.Start(8080)
-}
-
-func hookExitSignals() {
-	var captureSignalChan = make(chan os.Signal, 1)
-	// Relay stop signals to captureSignalChan
-	signal.Notify(captureSignalChan,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGABRT,
-		syscall.SIGQUIT,
-		syscall.SIGHUP)
-	signalHandler(<-captureSignalChan)
-}
-
-func signalHandler(signal os.Signal) {
-	fmt.Printf("\nCaught signal: %+v", signal)
-	fmt.Println("\nWait for 1 second to finish processing")
-	time.Sleep(1 * time.Second)
-
-	switch signal {
-
-	case syscall.SIGHUP: // kill -SIGHUP XXXX
-		fmt.Println("- got hungup")
-
-	case syscall.SIGINT: // kill -SIGINT XXXX or Ctrl+c
-		fmt.Println("- got ctrl+c")
-
-	case syscall.SIGTERM: // kill -SIGTERM XXXX
-		fmt.Println("- got force stop")
-
-	case syscall.SIGQUIT: // kill -SIGQUIT XXXX
-		fmt.Println("- stop and core dump")
-
-	case syscall.SIGABRT: // kill -SIGABRT XXXX
-		fmt.Println("- got abort signal")
-
-	case syscall.SIGKILL: // kill -SIGKILL XXXX
-		fmt.Println("- got kill signal")
-
-	default:
-		fmt.Println("- unknown signal")
-	}
-
-	fmt.Println("\nFinished server cleanup")
-	os.Exit(0)
 }

--- a/proxy.go
+++ b/proxy.go
@@ -85,7 +85,7 @@ func main() {
 
 	if useProxyClient == "1" {
 		// hook exit signals for remote action cleanup
-		go ap.HookExitSignals(make(chan os.Signal, 1))
+		go ap.HookExitSignals()
 	}
 
 	// start the balls rolling


### PR DESCRIPTION
This PR adds a way to cleanup remote actions when a client runtime is stopped and removed. Before exiting it will send a "/stop" request to the server runtime in order to cleanup the relative action, as the second point in https://github.com/apache/openserverless/issues/53#issuecomment-2373845501