### PR TITLE
Add test CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Test Go Proxy
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+    test:
+        name: Test Go Proxy
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout recursive
+            uses: actions/checkout@v2
+          - name: License check
+            uses: apache/skywalking-eyes@main
+          - name: Set up Go
+            uses: actions/setup-go@v2
+            with:
+              go-version: 1.23
+          - name: Run Go Tests
+            working-directory: ./openwhisk
+            run: go test -v

--- a/openwhisk/executor.go
+++ b/openwhisk/executor.go
@@ -130,7 +130,7 @@ func (proc *Executor) Start(waitForAck bool) error {
 	Debug("Start:")
 	err := proc.cmd.Start()
 	if err != nil {
-		Debug("run: early exit")
+		Debug("run: early exit: %e", err)
 		proc.cmd = nil // no need to kill
 		return fmt.Errorf("command exited")
 	}

--- a/openwhisk/stopHandler_test.go
+++ b/openwhisk/stopHandler_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestStopHandler(t *testing.T) {
+	oldCurrentDir, _ := os.Getwd()
 
 	actionID := "test-action-id"
 	// temporary workdir
@@ -37,6 +38,7 @@ func TestStopHandler(t *testing.T) {
 	file, _ := filepath.Abs("_test")
 	os.Symlink(file, dir+"/_test")
 	os.Chdir(dir)
+
 	// setup the server
 	buf, _ := os.CreateTemp("", "log")
 	rootAP := NewActionProxy(dir, "", buf, buf, ProxyModeServer)
@@ -53,11 +55,15 @@ func TestStopHandler(t *testing.T) {
 	doInit(ts, string(initBody))
 	require.Contains(t, rootAP.serverProxyData.actions, actionID)
 	lastAction := highestDir(dir)
+	require.Greater(t, lastAction, 0)
 
-	doRun(ts, "")
 	doStop(ts, actionID)
 
 	require.NotContains(t, rootAP.serverProxyData.actions, actionID)
 	require.NoDirExistsf(t, filepath.Join(dir, strconv.Itoa(lastAction)), "lastAction dir should be removed")
+	require.DirExists(t, dir)
 
+	os.RemoveAll(dir)
+
+	stopTestServer(ts, oldCurrentDir, buf)
 }


### PR DESCRIPTION
This PR  adds a new github action to run the go tests on pull requests and pushes to main. It also fixes the stop handler test where there was some missing cleanup after the test ends.