### PR TITLE
fix: 404 error when remote proxy is behind an LB or Reverse Proxy itself

### DIFF
--- a/openwhisk/forward_proxy.go
+++ b/openwhisk/forward_proxy.go
@@ -65,7 +65,7 @@ func (ap *ActionProxy) ForwardRunRequest(w http.ResponseWriter, r *http.Request)
 
 		req.URL.Scheme = ap.clientProxyData.ProxyURL.Scheme
 		req.URL.Host = ap.clientProxyData.ProxyURL.Host
-
+		req.Host = ap.clientProxyData.ProxyURL.Host
 	}
 
 	proxy := &httputil.ReverseProxy{Director: director}
@@ -123,6 +123,7 @@ func (ap *ActionProxy) ForwardInitRequest(w http.ResponseWriter, r *http.Request
 
 		req.URL.Scheme = ap.clientProxyData.ProxyURL.Scheme
 		req.URL.Host = ap.clientProxyData.ProxyURL.Host
+		req.Host = ap.clientProxyData.ProxyURL.Host
 	}
 
 	proxy := &httputil.ReverseProxy{Director: director}


### PR DESCRIPTION
This PR contributes a patch for proxy client to ensure that golang ReverseProxy is used setting explicitly the Host attribute on the proxied request.