### PR TITLE
Propagate remote logs to client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.25.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/openwhisk/forward_proxy_test.go
+++ b/openwhisk/forward_proxy_test.go
@@ -65,13 +65,13 @@ func Example_forwardInitRequest() {
 }
 
 func Example_forwardRunRequest() {
+	clientLog, _ := os.CreateTemp("", "log")
 	// create a client ActionProxy
-	clientAP := NewActionProxy("", "", nil, nil, ProxyModeClient)
+	clientAP := NewActionProxy("", "", clientLog, clientLog, ProxyModeClient)
 
 	// create a server ActionProxy
 	compiler, _ := filepath.Abs("common/gobuild.py")
-	log, _ := os.CreateTemp("", "log")
-	serverAP := NewActionProxy("./action", compiler, log, log, ProxyModeServer)
+	serverAP := NewActionProxy("./action", compiler, nil, nil, ProxyModeServer)
 
 	// start the server
 	ts := httptest.NewServer(serverAP)
@@ -95,8 +95,9 @@ func Example_forwardRunRequest() {
 	// wait 2 seconds before declaring a test done
 	time.Sleep(2 * time.Second)
 	ts.Close()
-	dump(log)
+	dump(clientLog)
 	fmt.Println(runW.Body.String())
+	os.Remove(clientLog.Name())
 
 	// Output:
 	// {"ok":true}

--- a/openwhisk/initHandler.go
+++ b/openwhisk/initHandler.go
@@ -70,7 +70,15 @@ func (ap *ActionProxy) initHandler(w http.ResponseWriter, r *http.Request) {
 			ap.serverProxyData = &ServerProxyData{actions: make(map[string]*ActionProxy)}
 		}
 
-		innerActionProxy := NewActionProxy(ap.baseDir, ap.compiler, ap.outFile, ap.errFile, ProxyModeNone)
+		outLog, err := os.CreateTemp("", "out-log")
+		if err != nil {
+			outLog = ap.outFile
+		}
+		errLog, err := os.CreateTemp("", "err-log")
+		if err != nil {
+			errLog = ap.errFile
+		}
+		innerActionProxy := NewActionProxy(ap.baseDir, ap.compiler, outLog, errLog, ProxyModeNone)
 		id, err := innerActionProxy.doInit(r, w)
 		if err != nil {
 			return

--- a/openwhisk/runHandler.go
+++ b/openwhisk/runHandler.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 )
 
 type runRequest struct {
@@ -33,6 +34,12 @@ type runRequest struct {
 // ErrResponse is the response when there are errors
 type ErrResponse struct {
 	Error string `json:"error"`
+}
+
+type RemoteRunResponse struct {
+	Response json.RawMessage `json:"response"`
+	Out      string          `json:"out"`
+	Err      string          `json:"err"`
 }
 
 func sendError(w http.ResponseWriter, code int, cause string) {
@@ -71,20 +78,21 @@ func (ap *ActionProxy) runHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		actionID := runRequest.ProxiedActionID
-
 		innerActionProxy, ok := ap.serverProxyData.actions[actionID]
 		if !ok {
 			Debug("Action %s not found in server proxy data", actionID)
 			sendError(w, http.StatusNotFound, "Action not found in remote runtime. Check logs for details.")
 		}
 
-		innerActionProxy.doProxiedRun(w, &runRequest)
+		innerActionProxy.doServerModeRun(w, &runRequest)
+
 		return
 	}
 
 	ap.doRun(w, r)
 }
-func (ap *ActionProxy) doProxiedRun(w http.ResponseWriter, bodyRequest *runRequest) {
+
+func (ap *ActionProxy) doServerModeRun(w http.ResponseWriter, bodyRequest *runRequest) {
 	var bodyBuf bytes.Buffer
 	err := json.NewEncoder(&bodyBuf).Encode(bodyRequest)
 	if err != nil {
@@ -93,7 +101,87 @@ func (ap *ActionProxy) doProxiedRun(w http.ResponseWriter, bodyRequest *runReque
 	}
 	body := bytes.Replace(bodyBuf.Bytes(), []byte("\n"), []byte(""), -1)
 
-	ap.executeAction(w, body)
+	// check if you have an action
+	if ap.theExecutor == nil {
+		sendError(w, http.StatusInternalServerError, "no action defined yet")
+		return
+	}
+
+	// check if the process exited
+	if ap.theExecutor.Exited() {
+		sendError(w, http.StatusInternalServerError, "command exited")
+		return
+	}
+
+	// execute the action
+	response, err := ap.theExecutor.Interact(body)
+
+	// check for early termination
+	if err != nil {
+		Debug("WARNING! Command exited")
+		ap.theExecutor = nil
+		sendError(w, http.StatusBadRequest, "command exited")
+		return
+	}
+	DebugLimit("received:", response, 120)
+
+	// check if the answer is an object map or array
+	var objmap map[string]*json.RawMessage
+	var objarray []interface{}
+	err = json.Unmarshal(response, &objmap)
+	if err != nil {
+		err = json.Unmarshal(response, &objarray)
+		if err != nil {
+			sendError(w, http.StatusBadGateway, "The action did not return a dictionary or array.")
+			return
+		}
+	}
+
+	// Get the stdout and stderr from the executor
+	outStr, err := os.ReadFile(ap.outFile.Name())
+	if err != nil {
+		outStr = []byte(fmt.Sprintf("Error reading stdout: %v", err))
+	}
+
+	errStr, err := os.ReadFile(ap.errFile.Name())
+	if err != nil {
+		errStr = []byte(fmt.Sprintf("Error reading stderr: %v", err))
+	}
+
+	// create the response
+	remoteResponse := RemoteRunResponse{
+		Response: response,
+		Out:      string(outStr),
+		Err:      string(errStr),
+	}
+
+	// turn response struct into json
+	responsePayload, err := json.Marshal(remoteResponse)
+	if err != nil {
+		sendError(w, http.StatusInternalServerError, fmt.Sprintf("Error marshalling response: %v", err))
+		return
+	}
+
+	// write response
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(responsePayload)))
+	numBytesWritten, err := w.Write(responsePayload)
+
+	// flush output if possible
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
+	// handle writing errors
+	if err != nil {
+		sendError(w, http.StatusInternalServerError, fmt.Sprintf("Error writing response: %v", err))
+		return
+	}
+	if numBytesWritten != len(response) {
+		sendError(w, http.StatusInternalServerError, fmt.Sprintf("Only wrote %d of %d bytes to response", numBytesWritten, len(response)))
+		return
+	}
+
 }
 
 func (ap *ActionProxy) doRun(w http.ResponseWriter, r *http.Request) {
@@ -107,10 +195,6 @@ func (ap *ActionProxy) doRun(w http.ResponseWriter, r *http.Request) {
 
 	body = bytes.Replace(body, []byte("\n"), []byte(""), -1)
 
-	ap.executeAction(w, body)
-}
-
-func (ap *ActionProxy) executeAction(w http.ResponseWriter, body []byte) {
 	// check if you have an action
 	if ap.theExecutor == nil {
 		sendError(w, http.StatusInternalServerError, "no action defined yet")

--- a/openwhisk/version.go
+++ b/openwhisk/version.go
@@ -17,4 +17,4 @@
 package openwhisk
 
 // Version number - internal
-var Version = "1.18.1"
+var Version = "1.18.2"

--- a/runtime/common/common1.18.2/Dockerfile
+++ b/runtime/common/common1.18.2/Dockerfile
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Do not fix the patch level for golang:1.19 to automatically get security fixes.
+FROM golang:1.21
+ENV HOME=/tmp
+USER nobody
+RUN CGO_ENABLED=0 go install github.com/apache/openserverless-runtimes@common1.18.2
+RUN mv /go/bin/openserverless-runtimes /go/bin/proxy
+ENTRYPOINT [ "/go/bin/proxy" ]

--- a/runtime/go/v1.22proxy/Dockerfile
+++ b/runtime/go/v1.22proxy/Dockerfile
@@ -19,7 +19,7 @@
 #ARG COMMON=missing:missing
 #FROM ${COMMON} AS builder
 
-FROM apache/openserverless-runtime-common:common1.18.1 AS builder
+FROM apache/openserverless-runtime-common:common1.18.2 AS builder
 
 FROM golang:1.22-bookworm
 ENV OW_EXECUTION_ENV=apacheopenserverless/runtime-golang-v1.22
@@ -31,15 +31,15 @@ RUN \
     apt-get upgrade -y --no-install-recommends &&\
     apt-get install -y apt-utils &&\
     apt-get install -y \
-     curl \
-     jq \
-     git \
-     zip \
-     vim && \
-     apt-get -y install \
-     librdkafka1 \
-     librdkafka++1 \
-     librdkafka-dev &&\
+    curl \
+    jq \
+    git \
+    zip \
+    vim && \
+    apt-get -y install \
+    librdkafka1 \
+    librdkafka++1 \
+    librdkafka-dev &&\
     # Cleanup apt data, we do not need them later on.
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
     go install github.com/go-delve/delve/cmd/dlv@latest &&\


### PR DESCRIPTION
This PR adds the out err logs in the response from the remote runtime in order for the client to grab them and print them out before replying to the user