### PR TITLE
Add reset endpoint for debug server mode

### DIFF
--- a/openwhisk/actionProxy.go
+++ b/openwhisk/actionProxy.go
@@ -204,6 +204,10 @@ func (ap *ActionProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "/stop":
 		ap.stopHandler(w, r)
 	}
+
+	if Debugging && r.URL.Path == "/reset" {
+		ap.resetHandler(w, r)
+	}
 }
 
 // Start creates a proxy to execute actions

--- a/openwhisk/forward_proxy.go
+++ b/openwhisk/forward_proxy.go
@@ -111,7 +111,6 @@ func (ap *ActionProxy) ForwardRunRequest(w http.ResponseWriter, r *http.Request)
 
 	Debug("Forwarding run request with id %s to %s", newBody.ProxiedActionID, ap.clientProxyData.ProxyURL.String())
 	proxy.ServeHTTP(w, r)
-	Debug("Run request forwarded. Response received: %s", w)
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()
 	}

--- a/openwhisk/resetHandler.go
+++ b/openwhisk/resetHandler.go
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openwhisk
+
+import (
+	"net/http"
+)
+
+func (ap *ActionProxy) resetHandler(w http.ResponseWriter, _ *http.Request) {
+	if ap.proxyMode != ProxyModeServer {
+		sendError(w, http.StatusMethodNotAllowed, "Reset allowed only in server mode")
+		return
+	}
+
+	for _, ap := range ap.serverProxyData.actions {
+		cleanUpAP(ap)
+	}
+
+	ap.serverProxyData.actions = make(map[string]*ActionProxy)
+
+	sendOK(w)
+}

--- a/openwhisk/stopHandler.go
+++ b/openwhisk/stopHandler.go
@@ -61,13 +61,16 @@ func (ap *ActionProxy) stopHandler(w http.ResponseWriter, r *http.Request) {
 		sendError(w, http.StatusNotFound, "Action to be removed in remote runtime not found. Check logs for details.")
 	}
 
-	innerAP.theExecutor.Stop()
 	Debug("Action '%s' executor stopped", actionID)
-	if err := os.RemoveAll(filepath.Join(innerAP.baseDir, strconv.Itoa(innerAP.currentDir))); err != nil {
-		Debug("Error removing action directory: %v", err)
-	}
-
+	cleanUpAP(innerAP)
 	delete(ap.serverProxyData.actions, actionID)
 
 	sendOK(w)
+}
+
+func cleanUpAP(ap *ActionProxy) {
+	ap.theExecutor.Stop()
+	if err := os.RemoveAll(filepath.Join(ap.baseDir, strconv.Itoa(ap.currentDir))); err != nil {
+		Debug("Error removing action directory: %v", err)
+	}
 }

--- a/openwhisk/version.go
+++ b/openwhisk/version.go
@@ -17,4 +17,4 @@
 package openwhisk
 
 // Version number - internal
-var Version = "1.18.2"
+var Version = "1.18.3"


### PR DESCRIPTION
This PR adds a new /reset endpoint for the runtime in server mode, enabled only when debug is enabled.

The endpoint will stop and remove all ActionProxy executors