### PR TITLE
fix: go1.22proxy should be based on common1.18.3

### DIFF
--- a/runtime/go/v1.22proxy/Dockerfile
+++ b/runtime/go/v1.22proxy/Dockerfile
@@ -19,7 +19,7 @@
 #ARG COMMON=missing:missing
 #FROM ${COMMON} AS builder
 
-FROM apache/openserverless-runtime-common:common1.18.2 AS builder
+FROM apache/openserverless-runtime-common:common1.18.3 AS builder
 
 FROM golang:1.22-bookworm
 ENV OW_EXECUTION_ENV=apacheopenserverless/runtime-golang-v1.22


### PR DESCRIPTION
fix: go1.22proxy should be based on common1.18.3