### PR TITLE
Fix duplicate server ap and cleanup

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -307,3 +307,20 @@ tasks:
         else echo "Build {{.SPECIFIC_RT}}"
           task build-experimental-lang RT={{.SPECIFIC_RT}} PUSH="{{.PUSH}}" DRY={{.DRY}}
         fi
+
+  debug-experimental-proxied-runtime:
+    desc: debug a runtime
+    requires: { vars: [RT, VER] }
+    cmds:
+      - >
+        BASEIMG="${MY_DOCKER_HUB_REGISTRY:-$DOCKER_HUB_REGISTRY}" ;
+        {{.DRY}} docker run -p 8081:8080 -e OW_ACTIVATE_PROXY_SERVER=1 -ti 
+        --entrypoint=/mnt/proxy-experimental -v $PWD:/mnt        
+        "${BASEIMG}/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}" -debug
+
+  debug-experimental-proxy:
+    desc: debug a runtime
+    requires: { vars: [RT, VER] }
+    cmds:
+      - export GOOS=linux; go build -o proxy-experimental
+      - task: debug-experimental-proxied-runtime

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3'
+version: "3"
 
 dotenv: [.env]
 
@@ -34,26 +34,25 @@ vars:
   J: "{}"
   RUNTIMES: "go,nodejs,php,python,java"
   EXPERIMENTAL_RUNTIMES: "python"
-  COMMIT_ID: 
+  COMMIT_ID:
     sh: git rev-parse --short HEAD
 
 tasks:
-
   default:
-  - task --list-all
+    - task --list-all
 
   setup:
-  # check we are running in ubuntu 
-  - grep '^ID=' /etc/os-release | grep -i ubuntu
-  - if ! which python3 | grep python3 ; then echo "python3 not found" ; exit 1; fi
-  - sudo apt-get -y install python3-pip python3-virtualenv
-  - python3 -m pip install ipython watchdog requests cram
-  
+    # check we are running in ubuntu
+    - grep '^ID=' /etc/os-release | grep -i ubuntu
+    - if ! which python3 | grep python3 ; then echo "python3 not found" ; exit 1; fi
+    - sudo apt-get -y install python3-pip python3-virtualenv
+    - python3 -m pip install ipython watchdog requests cram
+
   image-tag:
     silent: true
     cmds:
-      - git tag -d $(git tag) 
-      - | 
+      - git tag -d $(git tag)
+      - |
         if test -n "{{.RT}}"
         then git tag -f {{.RT}}.$(date +%y%m%d%H%M)
         else git tag -f $(date +%y%m%d%H%M)
@@ -63,9 +62,9 @@ tasks:
   common-tag:
     silent: true
     cmds:
-      - git tag -d $(git tag) 
+      - git tag -d $(git tag)
       - git tag -f common-$(date +%y%m%d%H%M)
-        
+
       - env PAGER= git tag
 
   experimental-tag:
@@ -73,55 +72,55 @@ tasks:
     cmds:
       - git tag -d $(git tag)
       - git tag -f experimental-$(date +%y%m%d%H%M)
-        
-      - env PAGER= git tag            
+
+      - env PAGER= git tag
 
   compile: go build -o proxy
 
-  test: 
+  test:
     dir: openwhisk
     cmds:
-    - go test -v
+      - go test -v
 
-  docker-login: 
+  docker-login:
     ignore_error: true
     cmds:
-    - echo ${MY_DOCKER_HUB_TOKEN:-$DOCKER_HUB_TOKEN} | docker login -u ${MY_DOCKER_HUB_USER:-$DOCKER_HUB_USER} --password-stdin registry.hub.docker.com
-    - >
-      {{.DRY}} docker run -it --rm --privileged tonistiigi/binfmt --install all
-    - >
-      {{.DRY}} docker buildx create --name mybuilder --bootstrap --use
+      - echo ${MY_DOCKER_HUB_TOKEN:-$DOCKER_HUB_TOKEN} | docker login -u ${MY_DOCKER_HUB_USER:-$DOCKER_HUB_USER} --password-stdin registry.hub.docker.com
+      - >
+        {{.DRY}} docker run -it --rm --privileged tonistiigi/binfmt --install all
+      - >
+        {{.DRY}} docker buildx create --name mybuilder --bootstrap --use
 
   clean-images:
-    - docker images -a | grep ghcr.io/nuvolaris | awk '{print $3}' | xargs docker rmi -f 
+    - docker images -a | grep ghcr.io/nuvolaris | awk '{print $3}' | xargs docker rmi -f
     - yes | docker buildx prune
 
   build-common:
     dir: "runtime/common/{{.COMMON_VER}}"
     cmds:
-    - |
-      if test -n "{{.PUSH}}"
-      then {{.DRY}} docker buildx build -t "{{.COMMON}}" --platform linux/amd64,linux/arm64 . --push
-      else {{.DRY}} docker buildx build -t "{{.COMMON}}" . --load
-      fi
+      - |
+        if test -n "{{.PUSH}}"
+        then {{.DRY}} docker buildx build -t "{{.COMMON}}" --platform linux/amd64,linux/arm64 . --push
+        else {{.DRY}} docker buildx build -t "{{.COMMON}}" . --load
+        fi
 
   build-runtime:
-    requires: { vars: [RT, VER] } 
+    requires: { vars: [RT, VER] }
     dir: "runtime/{{.RT}}/{{.VER}}"
     cmds:
-    - |
-      BASEIMG=$(echo "${MY_DOCKER_HUB_REGISTRY:-$DOCKER_HUB_REGISTRY}")
-      RUNTIME="{{.BASEIMG}}/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
-      if test -n "{{.PUSH}}"
-      then 
-        {{.DRY}} docker buildx build -t "$RUNTIME" --build-arg COMMON="{{.COMMON}}" --platform linux/amd64,linux/arm64 . --push    
-      else {{.DRY}} docker buildx build -t "$RUNTIME" --build-arg COMMON="{{.COMMON}}" . --load
-      fi
-      echo "Built $RUNTIME"
+      - |
+        BASEIMG=$(echo "${MY_DOCKER_HUB_REGISTRY:-$DOCKER_HUB_REGISTRY}")
+        RUNTIME="{{.BASEIMG}}/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
+        if test -n "{{.PUSH}}"
+        then 
+          {{.DRY}} docker buildx build -t "$RUNTIME" --build-arg COMMON="{{.COMMON}}" --platform linux/amd64,linux/arm64 . --push    
+        else {{.DRY}} docker buildx build -t "$RUNTIME" --build-arg COMMON="{{.COMMON}}" . --load
+        fi
+        echo "Built $RUNTIME"
 
   build-lang:
     desc: build images for one runtime
-    requires: {vars: [RT] }
+    requires: { vars: [RT] }
     vars:
       DIRS:
         sh: ls -d  runtime/{{.RT}}/v* || echo ""
@@ -133,14 +132,14 @@ tasks:
 
   build:
     silent: true
-    requires: { vars: [TAG,RUNTIMES] } 
+    requires: { vars: [TAG, RUNTIMES] }
     vars:
       RT_REGEX:
         sh: echo "{{.RUNTIMES}}" | tr ',' '|'
       SPECIFIC_RT:
         sh: echo "{{.TAG}}" | grep -E -o '({{.RT_REGEX}})' || echo ''
     cmds:
-      - |        
+      - |
         if [ -z "{{.SPECIFIC_RT}}" ];
         then
           echo "==> BUILDING RUNTIMES {{.RUNTIMES}}"
@@ -153,33 +152,33 @@ tasks:
         fi
 
   build-and-push:
-  - task build PUSH=y DRY={{.DRY}}
+    - task build PUSH=y DRY={{.DRY}}
 
   run:
     desc: run a runtime
-    requires: { vars: [RT, VER] } 
+    requires: { vars: [RT, VER] }
     dir: "runtime/{{.RT}}/{{.VER}}"
     cmds:
-    - >
-      {{.DRY}} docker run -p 8080:8080 -ti "{{.BASEIMG}}/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
-         
+      - >
+        {{.DRY}} docker run -p 8080:8080 -ti "{{.BASEIMG}}/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
+
   debug:
     desc: debug a runtime
-    requires: { vars: [RT, VER] } 
+    requires: { vars: [RT, VER] }
     dir: "runtime/{{.RT}}/{{.VER}}"
     cmds:
-    - >
-      {{.DRY}} docker run -p 8080:8080 -ti 
-      --entrypoint=/bin/bash -v $PWD:/mnt
-      -e OW_COMPILER=/mnt/bin/compile
-      "{{.BASEIMG}}/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
-      
+      - >
+        {{.DRY}} docker run -p 8080:8080 -ti 
+        --entrypoint=/bin/bash -v $PWD:/mnt
+        -e OW_COMPILER=/mnt/bin/compile
+        "{{.BASEIMG}}/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
+
   debug-experimental:
     desc: debug a runtime
-    requires: { vars: [RT, VER] } 
+    requires: { vars: [RT, VER] }
     dir: "runtime/experimental/{{.RT}}/{{.VER}}"
     cmds:
-    - >
+      - >
         BASEIMG="${MY_DOCKER_HUB_REGISTRY:-$DOCKER_HUB_REGISTRY}" ;
         {{.DRY}} docker run -p 8080:8080 -ti 
         --entrypoint=/bin/bash -v $PWD:/mnt
@@ -188,35 +187,34 @@ tasks:
 
   init:
     desc: intialize a runtime with a test
-    requires: { vars: [RT, VER, T] } 
+    requires: { vars: [RT, VER, T] }
     cmds:
-    - python3 packages/invoke.py init packages/{{.RT}}/{{.T}}.zip
+      - python3 packages/invoke.py init packages/{{.RT}}/{{.T}}.zip
 
   invoke:
     desc: invoke a runtime listening in port 8080, optionally with J=<json>
     cmds:
-    - python3 packages/invoke.py run '{{.J}}'
-
+      - python3 packages/invoke.py run '{{.J}}'
 
   render-runtime:
-    requires: { vars: [RT, VER] } 
+    requires: { vars: [RT, VER] }
     dir: "runtime/{{.RT}}/{{.VER}}"
     cmds:
-    - |
-      BASEIMG=$(echo "${MY_DOCKER_HUB_REGISTRY:-$DOCKER_HUB_REGISTRY}")
-      RUNTIME="{{.BASEIMG}}/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
-      ENVVER=$(echo "{{.VER}}" | tr '.' '_' | tr '[:upper:][:lower:]' '[:lower:][:upper:]')
-      ENVRT=$(echo "{{.RT}}" | tr '[a-zA-Z]' '[A-Za-z]')    
-      if test -n "{{.PUSH}}"
-      then 
-        {{.DRY}} echo "OPS_RUNTIME_TAG_${ENVRT}_${ENVVER}={{.VER}}-{{.TAG}}"  >> {{.BASE_DIR}}/runtimes.env
-      else {{.DRY}} echo "OPS_RUNTIME_TAG_${ENVRT}_${ENVVER}={{.VER}}-{{.TAG}}"
-      fi
-      echo "Rendered $RUNTIME"
+      - |
+        BASEIMG=$(echo "${MY_DOCKER_HUB_REGISTRY:-$DOCKER_HUB_REGISTRY}")
+        RUNTIME="{{.BASEIMG}}/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
+        ENVVER=$(echo "{{.VER}}" | tr '.' '_' | tr '[:upper:][:lower:]' '[:lower:][:upper:]')
+        ENVRT=$(echo "{{.RT}}" | tr '[a-zA-Z]' '[A-Za-z]')    
+        if test -n "{{.PUSH}}"
+        then 
+          {{.DRY}} echo "OPS_RUNTIME_TAG_${ENVRT}_${ENVVER}={{.VER}}-{{.TAG}}"  >> {{.BASE_DIR}}/runtimes.env
+        else {{.DRY}} echo "OPS_RUNTIME_TAG_${ENVRT}_${ENVVER}={{.VER}}-{{.TAG}}"
+        fi
+        echo "Rendered $RUNTIME"
 
   render-lang:
     desc: render images for one runtime
-    requires: {vars: [RT,BASE_DIR] }
+    requires: { vars: [RT, BASE_DIR] }
     vars:
       DIRS:
         sh: ls -d  runtime/{{.RT}}/v* || echo ""
@@ -229,16 +227,16 @@ tasks:
 
   render:
     silent: true
-    requires: { vars: [TAG,RUNTIMES] } 
+    requires: { vars: [TAG, RUNTIMES] }
     vars:
       RT_REGEX:
         sh: echo "{{.RUNTIMES}}" | tr ',' '|'
       SPECIFIC_RT:
         sh: echo "{{.TAG}}" | grep -E -o '({{.RT_REGEX}})' || echo ''
       BASE_DIR:
-        sh: pwd  
+        sh: pwd
     cmds:
-      - |      
+      - |
         rm -f runtimes.env
         echo "OPS_RUNTIME_PREFIX={{.REPO_PATH}}" >> runtimes.env
         echo "==> RENDERING RUNTIMES {{.RUNTIMES}}"
@@ -249,7 +247,7 @@ tasks:
 
   generate-runtimes:
     silent: true
-    dotenv: 
+    dotenv:
       - runtimes.env
     cmds:
       - cat runtimes.json.tpl | envsubst  > runtimes.json
@@ -263,23 +261,23 @@ tasks:
         task generate-runtimes
 
   build-experimental-runtime:
-    requires: { vars: [RT, VER] } 
+    requires: { vars: [RT, VER] }
     dir: "runtime/experimental/{{.RT}}/{{.VER}}"
     cmds:
-    - |
-      BASEIMG=$(echo "${MY_DOCKER_HUB_REGISTRY:-$DOCKER_HUB_REGISTRY}")
-      RUNTIME="$BASEIMG/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
-      PLATFORMS=$(cat platforms.txt)
-      if test -n "{{.PUSH}}"
-      then 
-        {{.DRY}} docker buildx build -t "$RUNTIME" --build-arg COMMON="{{.EXPERIMENTAL_COMMON}}" --platform "$PLATFORMS" . --push
-      else {{.DRY}} docker buildx build -t "$RUNTIME" --build-arg COMMON="{{.EXPERIMENTAL_COMMON}}" . --load
-      fi
-      echo "Built $RUNTIME on platforms $PLATFORMS"        
+      - |
+        BASEIMG=$(echo "${MY_DOCKER_HUB_REGISTRY:-$DOCKER_HUB_REGISTRY}")
+        RUNTIME="$BASEIMG/openserverless-runtime-{{.RT}}:{{.VER}}-{{.TAG}}"
+        PLATFORMS=$(cat platforms.txt)
+        if test -n "{{.PUSH}}"
+        then 
+          {{.DRY}} docker buildx build -t "$RUNTIME" --build-arg COMMON="{{.EXPERIMENTAL_COMMON}}" --platform "$PLATFORMS" . --push
+        else {{.DRY}} docker buildx build -t "$RUNTIME" --build-arg COMMON="{{.EXPERIMENTAL_COMMON}}" . --load
+        fi
+        echo "Built $RUNTIME on platforms $PLATFORMS"
 
   build-experimental-lang:
     desc: build images for experimental runtimes
-    requires: {vars: [RT] }
+    requires: { vars: [RT] }
     vars:
       DIRS:
         sh: ls -d runtime/experimental/{{.RT}}/v* || echo ""
@@ -291,14 +289,14 @@ tasks:
 
   build-experimental-runtimes:
     silent: true
-    requires: { vars: [TAG,EXPERIMENTAL_RUNTIMES] } 
+    requires: { vars: [TAG, EXPERIMENTAL_RUNTIMES] }
     vars:
       RT_REGEX:
         sh: echo "{{.EXPERIMENTAL_RUNTIMES}}" | tr ',' '|'
       SPECIFIC_RT:
         sh: echo "{{.TAG}}" | grep -E -o '({{.RT_REGEX}})' || echo ''
     cmds:
-      - |        
+      - |
         if [ -z "{{.SPECIFIC_RT}}" ];
         then
           echo "==> BUILDING RUNTIMES {{.EXPERIMENTAL_RUNTIMES}}"
@@ -308,4 +306,4 @@ tasks:
           done
         else echo "Build {{.SPECIFIC_RT}}"
           task build-experimental-lang RT={{.SPECIFIC_RT}} PUSH="{{.PUSH}}" DRY={{.DRY}}
-        fi                        
+        fi

--- a/openwhisk/actionProxy.go
+++ b/openwhisk/actionProxy.go
@@ -56,6 +56,7 @@ type RemoteAPKey = string
 type RemoteAPValue struct {
 	remoteProxy        *ActionProxy
 	connectedActionIDs []string
+	runRequestQueue    chan *remoteRunChanPayload
 }
 
 // ActionProxy is the container of the data specific to a server

--- a/openwhisk/actionProxy.go
+++ b/openwhisk/actionProxy.go
@@ -41,13 +41,21 @@ const (
 )
 
 type ClientProxyData struct {
-	ProxyActionID string
-	MainFunc      string
-	ProxyURL      url.URL
+	ProxyActionID  string
+	ActionCodeHash string
+	MainFunc       string
+	ProxyURL       url.URL
 }
 
 type ServerProxyData struct {
-	actions map[string]*ActionProxy
+	actions map[RemoteAPKey]*RemoteAPValue
+}
+
+type RemoteAPKey = string
+
+type RemoteAPValue struct {
+	remoteProxy        *ActionProxy
+	connectedActionIDs []string
 }
 
 // ActionProxy is the container of the data specific to a server

--- a/openwhisk/forward_proxy.go
+++ b/openwhisk/forward_proxy.go
@@ -48,7 +48,7 @@ func (ap *ActionProxy) ForwardRunRequest(w http.ResponseWriter, r *http.Request)
 	}
 
 	newBody := runRequest
-	newBody.ProxiedActionID = ap.clientProxyData.ProxyActionID
+	newBody.ActionCodeHash = ap.clientProxyData.ActionCodeHash
 
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(newBody)
@@ -109,7 +109,7 @@ func (ap *ActionProxy) ForwardRunRequest(w http.ResponseWriter, r *http.Request)
 		return nil
 	}
 
-	Debug("Forwarding run request with id %s to %s", newBody.ProxiedActionID, ap.clientProxyData.ProxyURL.String())
+	Debug("Forwarding run request with to %s", ap.clientProxyData.ProxyURL.String())
 	proxy.ServeHTTP(w, r)
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()
@@ -143,6 +143,7 @@ func (ap *ActionProxy) ForwardInitRequest(w http.ResponseWriter, r *http.Request
 		newBody.Value.Env = make(map[string]interface{})
 	}
 	newBody.Value.Env[OW_CODE_HASH] = codeHash
+	ap.clientProxyData.ActionCodeHash = codeHash
 
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(newBody)

--- a/openwhisk/forward_proxy_test.go
+++ b/openwhisk/forward_proxy_test.go
@@ -91,10 +91,12 @@ func Example_forwardInitRequest() {
 	ts.Close()
 	dump(log)
 
-	fmt.Println(w.Body.String())
+	fmt.Print(w.Body.String())
+	fmt.Println(clientAP.clientProxyData.ActionCodeHash != "")
 
 	// Output:
 	// {"ok":true}
+	// true
 }
 
 func Example_forwardRunRequest() {

--- a/openwhisk/forward_proxy_test.go
+++ b/openwhisk/forward_proxy_test.go
@@ -139,7 +139,6 @@ func Example_forwardRunRequest() {
 	// Main
 	// Hello, Mike
 	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
-	// XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX
 	// {"greetings":"Hello, Mike"}
 }
 

--- a/openwhisk/initHandler.go
+++ b/openwhisk/initHandler.go
@@ -154,7 +154,11 @@ func doRemoteInit(ap *ActionProxy, request initRequest, w http.ResponseWriter) b
 	ap.serverProxyData.actions[actionCodeHash] = &RemoteAPValue{
 		remoteProxy:        innerActionProxy,
 		connectedActionIDs: []string{request.ProxiedActionID},
+		runRequestQueue:    make(chan *remoteRunChanPayload, 50), // size could be determined empirically
 	}
+
+	Debug("Started listening to run requests for AP with code hash %s...", actionCodeHash)
+	go startListenToRunRequests(innerActionProxy, ap.serverProxyData.actions[actionCodeHash].runRequestQueue)
 
 	Debug("Added action id %s to action hash %s", request.ProxiedActionID, actionCodeHash)
 	return true

--- a/openwhisk/resetHandler.go
+++ b/openwhisk/resetHandler.go
@@ -26,8 +26,14 @@ func (ap *ActionProxy) resetHandler(w http.ResponseWriter, _ *http.Request) {
 		sendError(w, http.StatusMethodNotAllowed, "Reset allowed only in server mode")
 		return
 	}
-	for _, ap := range ap.serverProxyData.actions {
-		cleanUpAP(ap.remoteProxy)
+
+	if ap.serverProxyData.actions == nil {
+		sendOK(w)
+		return
+	}
+
+	for _, nestedAP := range ap.serverProxyData.actions {
+		cleanUpAP(nestedAP.remoteProxy)
 	}
 	ap.serverProxyData.actions = make(map[RemoteAPKey]*RemoteAPValue)
 	sendOK(w)

--- a/openwhisk/resetHandler.go
+++ b/openwhisk/resetHandler.go
@@ -26,12 +26,9 @@ func (ap *ActionProxy) resetHandler(w http.ResponseWriter, _ *http.Request) {
 		sendError(w, http.StatusMethodNotAllowed, "Reset allowed only in server mode")
 		return
 	}
-
 	for _, ap := range ap.serverProxyData.actions {
-		cleanUpAP(ap)
+		cleanUpAP(ap.remoteProxy)
 	}
-
-	ap.serverProxyData.actions = make(map[string]*ActionProxy)
-
+	ap.serverProxyData.actions = make(map[RemoteAPKey]*RemoteAPValue)
 	sendOK(w)
 }

--- a/openwhisk/runHandler.go
+++ b/openwhisk/runHandler.go
@@ -27,8 +27,8 @@ import (
 )
 
 type runRequest struct {
-	ProxiedActionID string                 `json:"proxiedActionID,omitempty"`
-	Value           map[string]interface{} `json:"value,omitempty"`
+	ActionCodeHash string                 `json:"actionCodeHash,omitempty"`
+	Value          map[string]interface{} `json:"value,omitempty"`
 }
 
 // ErrResponse is the response when there are errors
@@ -77,15 +77,15 @@ func (ap *ActionProxy) runHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		actionID := runRequest.ProxiedActionID
-		innerActionProxy, ok := ap.serverProxyData.actions[actionID]
+		actionHash := runRequest.ActionCodeHash
+		innerActionProxy, ok := ap.serverProxyData.actions[actionHash]
 		if !ok {
-			Debug("Action %s not found in server proxy data", actionID)
+			Debug("Action hash %s not found in server proxy data", actionHash)
 			sendError(w, http.StatusNotFound, "Action not found in remote runtime. Check logs for details.")
 			return
 		}
 
-		innerActionProxy.doServerModeRun(w, &runRequest)
+		innerActionProxy.remoteProxy.doServerModeRun(w, &runRequest)
 		return
 	}
 

--- a/openwhisk/runHandler.go
+++ b/openwhisk/runHandler.go
@@ -188,6 +188,9 @@ func (ap *ActionProxy) doServerModeRun(bodyRequest *runRequest) (RemoteRunRespon
 	if err != nil {
 		errStr = []byte(fmt.Sprintf("Error reading stderr: %v", err))
 	}
+	// clear out the files
+	os.Truncate(ap.outFile.Name(), 0)
+	os.Truncate(ap.errFile.Name(), 0)
 
 	// create the response struct
 	remoteResponse := RemoteRunResponse{

--- a/openwhisk/stopHandler.go
+++ b/openwhisk/stopHandler.go
@@ -62,7 +62,7 @@ func (ap *ActionProxy) stopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	Debug("Action '%s' executor stopped", actionID)
-	cleanUpAP(innerAP)
+	cleanUpAP(innerAP.remoteProxy)
 	delete(ap.serverProxyData.actions, actionID)
 
 	sendOK(w)

--- a/openwhisk/stopHandler.go
+++ b/openwhisk/stopHandler.go
@@ -79,6 +79,7 @@ func (ap *ActionProxy) stopHandler(w http.ResponseWriter, r *http.Request) {
 	Debug("Removed action ID. Length of connectedActionIDs: %d", len(innerAPValue.connectedActionIDs))
 	if len(innerAPValue.connectedActionIDs) == 0 {
 		Debug("Action hash '%s' executor stopped", stopRequest.ActionCodeHash)
+		close(innerAPValue.runRequestQueue)
 		cleanUpAP(innerAPValue.remoteProxy)
 		delete(ap.serverProxyData.actions, stopRequest.ActionCodeHash)
 	}

--- a/openwhisk/stopHandler.go
+++ b/openwhisk/stopHandler.go
@@ -65,7 +65,7 @@ func (ap *ActionProxy) stopHandler(w http.ResponseWriter, r *http.Request) {
 	for i, connectedID := range innerAPValue.connectedActionIDs {
 		if connectedID == stopRequest.ProxiedActionID {
 			// remove id from the array
-			removeID(innerAPValue.connectedActionIDs, i)
+			innerAPValue.connectedActionIDs = removeID(innerAPValue.connectedActionIDs, i)
 			connectedIDFound = true
 			break
 		}
@@ -76,8 +76,8 @@ func (ap *ActionProxy) stopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	Debug("Removed action ID. Length of connectedActionIDs: %d", len(innerAPValue.connectedActionIDs))
 	if len(innerAPValue.connectedActionIDs) == 0 {
-
 		Debug("Action hash '%s' executor stopped", stopRequest.ActionCodeHash)
 		cleanUpAP(innerAPValue.remoteProxy)
 		delete(ap.serverProxyData.actions, stopRequest.ActionCodeHash)

--- a/openwhisk/stopHandler_test.go
+++ b/openwhisk/stopHandler_test.go
@@ -276,8 +276,8 @@ func TestStopHandler(t *testing.T) {
 		err := os.WriteFile(setupCheckFile, []byte("setup"), 0644)
 		require.NoError(t, err)
 
-		oldtimerToDeletion := timerToDeletion
-		timerToDeletion = 100 * time.Millisecond
+		oldtimerToDeletion := timeToDeletion
+		timeToDeletion = 100 * time.Millisecond
 		doStop(ts, actionCodeHash, actionID)
 
 		require.Contains(t, rootAP.serverProxyData.actions, actionCodeHash)
@@ -292,7 +292,7 @@ func TestStopHandler(t *testing.T) {
 
 		stopTestServer(ts, oldCurrentDir, buf)
 
-		timerToDeletion = oldtimerToDeletion
+		timeToDeletion = oldtimerToDeletion
 		setupActionPath = oldSetupActionPath
 	})
 }

--- a/openwhisk/stopHandler_test.go
+++ b/openwhisk/stopHandler_test.go
@@ -51,15 +51,17 @@ func TestStopHandler(t *testing.T) {
 	dat, _ := os.ReadFile("_test/hello_message")
 	enc := base64.StdEncoding.EncodeToString(dat)
 	body := initBodyRequest{Binary: true, Code: enc}
+
 	actionCodeHash := calculateCodeHash(enc)
 	body.Env = map[string]interface{}{OW_CODE_HASH: actionCodeHash}
+
 	initBody, _ := json.Marshal(initRequest{Value: body, ProxiedActionID: actionID})
 	doInit(ts, string(initBody))
 	require.Contains(t, rootAP.serverProxyData.actions, actionCodeHash)
 	lastAction := highestDir(dir)
 	require.Greater(t, lastAction, 0)
 
-	doStop(ts, actionCodeHash)
+	doStop(ts, actionCodeHash, actionID)
 
 	require.NotContains(t, rootAP.serverProxyData.actions, actionCodeHash)
 	require.NoDirExistsf(t, filepath.Join(dir, strconv.Itoa(lastAction)), "lastAction dir should be removed")

--- a/openwhisk/stopHandler_test.go
+++ b/openwhisk/stopHandler_test.go
@@ -30,44 +30,259 @@ import (
 )
 
 func TestStopHandler(t *testing.T) {
-	oldCurrentDir, _ := os.Getwd()
+	t.Run("clean up action", func(t *testing.T) {
+		oldCurrentDir, _ := os.Getwd()
 
-	actionID := "test-action-id"
-	// temporary workdir
-	dir, _ := os.MkdirTemp("", "action")
-	file, _ := filepath.Abs("_test")
-	os.Symlink(file, dir+"/_test")
-	os.Chdir(dir)
+		actionID := "test-action-id"
+		// temporary workdir
+		dir, _ := os.MkdirTemp("", "action")
+		file, _ := filepath.Abs("_test")
+		os.Symlink(file, dir+"/_test")
+		os.Chdir(dir)
 
-	// setup the server
-	buf, _ := os.CreateTemp("", "log")
-	rootAP := NewActionProxy(dir, "", buf, buf, ProxyModeServer)
-	rootAP.serverProxyData = &ServerProxyData{
-		actions: make(map[RemoteAPKey]*RemoteAPValue),
-	}
+		// setup the server
+		buf, _ := os.CreateTemp("", "log")
+		rootAP := NewActionProxy(dir, "", buf, buf, ProxyModeServer)
+		rootAP.serverProxyData = &ServerProxyData{
+			actions: make(map[RemoteAPKey]*RemoteAPValue),
+		}
 
-	ts := httptest.NewServer(rootAP)
+		ts := httptest.NewServer(rootAP)
 
-	dat, _ := os.ReadFile("_test/hello_message")
-	enc := base64.StdEncoding.EncodeToString(dat)
-	body := initBodyRequest{Binary: true, Code: enc}
+		dat, _ := os.ReadFile("_test/hello_message")
+		enc := base64.StdEncoding.EncodeToString(dat)
+		body := initBodyRequest{Binary: true, Code: enc}
 
-	actionCodeHash := calculateCodeHash(enc)
-	body.Env = map[string]interface{}{OW_CODE_HASH: actionCodeHash}
+		actionCodeHash := calculateCodeHash(enc)
+		body.Env = map[string]interface{}{OW_CODE_HASH: actionCodeHash}
 
-	initBody, _ := json.Marshal(initRequest{Value: body, ProxiedActionID: actionID})
-	doInit(ts, string(initBody))
-	require.Contains(t, rootAP.serverProxyData.actions, actionCodeHash)
-	lastAction := highestDir(dir)
-	require.Greater(t, lastAction, 0)
+		initBody, _ := json.Marshal(initRequest{Value: body, ProxiedActionID: actionID})
+		doInit(ts, string(initBody))
+		require.Contains(t, rootAP.serverProxyData.actions, actionCodeHash)
+		lastAction := highestDir(dir)
+		require.Greater(t, lastAction, 0)
 
-	doStop(ts, actionCodeHash, actionID)
+		doStop(ts, actionCodeHash, actionID)
 
-	require.NotContains(t, rootAP.serverProxyData.actions, actionCodeHash)
-	require.NoDirExistsf(t, filepath.Join(dir, strconv.Itoa(lastAction)), "lastAction dir should be removed")
-	require.DirExists(t, dir)
+		require.NotContains(t, rootAP.serverProxyData.actions, actionCodeHash)
+		require.NoDirExistsf(t, filepath.Join(dir, strconv.Itoa(lastAction)), "lastAction dir should be removed")
+		require.DirExists(t, dir)
 
-	os.RemoveAll(dir)
+		os.RemoveAll(dir)
 
-	stopTestServer(ts, oldCurrentDir, buf)
+		stopTestServer(ts, oldCurrentDir, buf)
+	})
+
+	t.Run("don't clean up action when other clients still present", func(t *testing.T) {
+		oldCurrentDir, _ := os.Getwd()
+
+		actionID := "test-action-id"
+		otherActionID := "other-action-id"
+		// temporary workdir
+		dir, _ := os.MkdirTemp("", "action")
+		file, _ := filepath.Abs("_test")
+		os.Symlink(file, dir+"/_test")
+		os.Chdir(dir)
+
+		// setup the server
+		buf, _ := os.CreateTemp("", "log")
+		rootAP := NewActionProxy(dir, "", buf, buf, ProxyModeServer)
+		rootAP.serverProxyData = &ServerProxyData{
+			actions: make(map[RemoteAPKey]*RemoteAPValue),
+		}
+
+		ts := httptest.NewServer(rootAP)
+
+		dat, _ := os.ReadFile("_test/hello_message")
+		enc := base64.StdEncoding.EncodeToString(dat)
+		body := initBodyRequest{Binary: true, Code: enc}
+
+		actionCodeHash := calculateCodeHash(enc)
+		body.Env = map[string]interface{}{OW_CODE_HASH: actionCodeHash}
+
+		// first client
+		initBody, _ := json.Marshal(initRequest{Value: body, ProxiedActionID: actionID})
+		doInit(ts, string(initBody))
+
+		// second client
+		initBody, _ = json.Marshal(initRequest{Value: body, ProxiedActionID: otherActionID})
+		doInit(ts, string(initBody))
+
+		require.Contains(t, rootAP.serverProxyData.actions, actionCodeHash)
+
+		lastAction := highestDir(dir)
+		require.Greater(t, lastAction, 0)
+
+		doStop(ts, actionCodeHash, actionID)
+
+		require.Contains(t, rootAP.serverProxyData.actions, actionCodeHash)
+		require.DirExistsf(t, filepath.Join(dir, strconv.Itoa(lastAction)), "lastAction dir should still exist")
+		require.DirExists(t, dir)
+
+		os.RemoveAll(dir)
+
+		stopTestServer(ts, oldCurrentDir, buf)
+	})
+
+	t.Run("don't clean up action when special action setup is still running", func(t *testing.T) {
+		oldCurrentDir, _ := os.Getwd()
+
+		oldSetupActionPath := setupActionPath
+		tmpDir := t.TempDir()
+		setupActionPath = tmpDir
+
+		actionID := "test-action-id"
+
+		// temporary workdir
+		dir, _ := os.MkdirTemp("", "action")
+		file, _ := filepath.Abs("_test")
+		os.Symlink(file, dir+"/_test")
+		os.Chdir(dir)
+
+		// setup the server
+		buf, _ := os.CreateTemp("", "log")
+		rootAP := NewActionProxy(dir, "", buf, buf, ProxyModeServer)
+		rootAP.serverProxyData = &ServerProxyData{
+			actions: make(map[RemoteAPKey]*RemoteAPValue),
+		}
+
+		ts := httptest.NewServer(rootAP)
+
+		dat, _ := os.ReadFile("_test/hello_message")
+		enc := base64.StdEncoding.EncodeToString(dat)
+		body := initBodyRequest{Binary: true, Code: enc}
+
+		actionCodeHash := calculateCodeHash(enc)
+		body.Env = map[string]interface{}{OW_CODE_HASH: actionCodeHash}
+
+		initBody, _ := json.Marshal(initRequest{Value: body, ProxiedActionID: actionID})
+		doInit(ts, string(initBody))
+		require.Contains(t, rootAP.serverProxyData.actions, actionCodeHash)
+		lastAction := highestDir(dir)
+		require.Greater(t, lastAction, 0)
+
+		setupCheckFile := filepath.Join(setupActionPath, actionCodeHash)
+		err := os.WriteFile(setupCheckFile, []byte("setup"), 0644)
+		require.NoError(t, err)
+
+		doStop(ts, actionCodeHash, actionID)
+
+		require.Contains(t, rootAP.serverProxyData.actions, actionCodeHash)
+		require.Empty(t, rootAP.serverProxyData.actions[actionCodeHash].connectedActionIDs)
+		require.DirExistsf(t, filepath.Join(dir, strconv.Itoa(lastAction)), "lastAction dir should not be removed during setup")
+		require.DirExists(t, dir)
+
+		os.RemoveAll(dir)
+		os.Remove(setupCheckFile)
+
+		stopTestServer(ts, oldCurrentDir, buf)
+		setupActionPath = oldSetupActionPath
+	})
+
+	t.Run("clean up action when special action setup is completed", func(t *testing.T) {
+		oldCurrentDir, _ := os.Getwd()
+
+		oldSetupActionPath := setupActionPath
+		tmpDir := t.TempDir()
+		setupActionPath = tmpDir
+
+		actionID := "test-action-id"
+
+		// temporary workdir
+		dir, _ := os.MkdirTemp("", "action")
+		file, _ := filepath.Abs("_test")
+		os.Symlink(file, dir+"/_test")
+		os.Chdir(dir)
+
+		// setup the server
+		buf, _ := os.CreateTemp("", "log")
+		rootAP := NewActionProxy(dir, "", buf, buf, ProxyModeServer)
+		rootAP.serverProxyData = &ServerProxyData{
+			actions: make(map[RemoteAPKey]*RemoteAPValue),
+		}
+
+		ts := httptest.NewServer(rootAP)
+
+		dat, _ := os.ReadFile("_test/hello_message")
+		enc := base64.StdEncoding.EncodeToString(dat)
+		body := initBodyRequest{Binary: true, Code: enc}
+
+		actionCodeHash := calculateCodeHash(enc)
+		body.Env = map[string]interface{}{OW_CODE_HASH: actionCodeHash}
+
+		initBody, _ := json.Marshal(initRequest{Value: body, ProxiedActionID: actionID})
+		doInit(ts, string(initBody))
+		require.Contains(t, rootAP.serverProxyData.actions, actionCodeHash)
+		lastAction := highestDir(dir)
+		require.Greater(t, lastAction, 0)
+
+		setupCheckFile := filepath.Join(setupActionPath, actionCodeHash)
+		setupDoneFile := setupCheckFile + "_done"
+		err := os.WriteFile(setupCheckFile, []byte("setup"), 0644)
+		require.NoError(t, err)
+		err = os.WriteFile(setupDoneFile, []byte("done"), 0644)
+		require.NoError(t, err)
+
+		doStop(ts, actionCodeHash, actionID)
+
+		require.NotContains(t, rootAP.serverProxyData.actions, actionCodeHash)
+		require.NoDirExistsf(t, filepath.Join(dir, strconv.Itoa(lastAction)), "lastAction dir should be removed")
+		require.DirExists(t, dir)
+
+		os.RemoveAll(dir)
+
+		stopTestServer(ts, oldCurrentDir, buf)
+		setupActionPath = oldSetupActionPath
+	})
+
+}
+func TestIsSetupActionRunning(t *testing.T) {
+	oldSetupActionPath := setupActionPath
+
+	t.Run("setup action is running", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupActionPath = tmpDir
+		actionCodeHash := "test-action-hash"
+		setupCheckFile := filepath.Join(setupActionPath, actionCodeHash)
+
+		// Create the setup check file
+		err := os.WriteFile(setupCheckFile, []byte("setup"), 0644)
+		require.NoError(t, err)
+
+		// Check if setup action is running
+		running := isSetupActionRunning(actionCodeHash)
+		require.True(t, running)
+	})
+
+	t.Run("setup action is not running", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupActionPath = tmpDir
+		actionCodeHash := "test-action-hash"
+
+		// Check if setup action is running
+		running := isSetupActionRunning(actionCodeHash)
+		require.False(t, running)
+	})
+
+	t.Run("setup action is completed", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupActionPath = tmpDir
+		actionCodeHash := "test-action-hash"
+		setupCheckFile := filepath.Join(setupActionPath, actionCodeHash)
+		setupDoneFile := setupCheckFile + "_done"
+
+		// Create the setup check file
+		err := os.WriteFile(setupCheckFile, []byte("setup"), 0644)
+		require.NoError(t, err)
+
+		// Create the setup done file
+		err = os.WriteFile(setupDoneFile, []byte("done"), 0644)
+		require.NoError(t, err)
+
+		// Check if setup action is running
+		running := isSetupActionRunning(actionCodeHash)
+		require.False(t, running)
+	})
+
+	setupActionPath = oldSetupActionPath
 }

--- a/openwhisk/stopper.go
+++ b/openwhisk/stopper.go
@@ -52,14 +52,14 @@ func listenOnExitSignals(ap *ActionProxy, captureSignalChan chan os.Signal) {
 func signalHandler(signal os.Signal, ap *ActionProxy) {
 	Debug("Caught signal: %v", signal)
 
-	_ = ap.SendStopRequest()
+	_ = SendStopRequest(ap)
 
 	Debug("Finished remote action cleanup. Exiting.")
 }
 
-func (ap *ActionProxy) SendStopRequest() error {
+func SendStopRequest(ap *ActionProxy) error {
 	if ap.clientProxyData == nil {
-		Debug("Nothing to stop")
+		Debug("Nothing to stop, runtime not set as client")
 		return fmt.Errorf("runtime not set as client")
 	}
 

--- a/openwhisk/stopper.go
+++ b/openwhisk/stopper.go
@@ -65,6 +65,7 @@ func SendStopRequest(ap *ActionProxy) error {
 
 	stopRequest := stopRequest{
 		ProxiedActionID: ap.clientProxyData.ProxyActionID,
+		ActionCodeHash:  ap.clientProxyData.ActionCodeHash,
 	}
 
 	var buf bytes.Buffer

--- a/openwhisk/stopper_test.go
+++ b/openwhisk/stopper_test.go
@@ -32,7 +32,7 @@ func TestSendStopRequest(t *testing.T) {
 
 	t.Run("clientProxyData is nil", func(t *testing.T) {
 		ap := &ActionProxy{}
-		err := ap.SendStopRequest()
+		err := SendStopRequest(ap)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "runtime not set as client")
 	})
@@ -53,7 +53,7 @@ func TestSendStopRequest(t *testing.T) {
 			},
 		}
 
-		err := ap.SendStopRequest()
+		err := SendStopRequest(ap)
 		require.NoError(t, err)
 	})
 }

--- a/openwhisk/util_test.go
+++ b/openwhisk/util_test.go
@@ -100,8 +100,11 @@ func doInit(ts *httptest.Server, message string) {
 	}
 }
 
-func doStop(ts *httptest.Server, actionID string) {
-	resp, status, err := doPost(ts.URL+"/stop", fmt.Sprintf(`{"proxiedActionID":"%s"}`, actionID))
+func doStop(ts *httptest.Server, actionCodeHash string, actionID string) {
+	resp, status, err := doPost(
+		ts.URL+"/stop",
+		fmt.Sprintf(`{"proxiedActionID":"%s", "actionCodeHash":"%s"}`, actionID, actionCodeHash),
+	)
 	if err != nil {
 		fmt.Println(err)
 	} else {

--- a/openwhisk/version.go
+++ b/openwhisk/version.go
@@ -17,4 +17,4 @@
 package openwhisk
 
 // Version number - internal
-var Version = "1.18.3"
+var Version = "1.18.4"

--- a/proxy.go
+++ b/proxy.go
@@ -85,7 +85,7 @@ func main() {
 
 	if useProxyClient == "1" {
 		// hook exit signals for remote action cleanup
-		//go ap.HookExitSignals()
+		go ap.HookExitSignals()
 		openwhisk.Debug("OpenWhisk ActionLoop Proxy HookExitSignals() disabled")
 	}
 


### PR DESCRIPTION
This PR bumps the internal version to 1.18.4. It adds:

- use action code hash to keep track of remote action instances instead of id so multiple action clients do not duplication the remote action
- new system for cleanup that keeps track of the amount of client action instances. When there are no more clients the clean up is triggered
- synchronize multiple action invocations on the same remote instance via a channel
- keep track of the special setup action to avoid deletion while a setup is going