### PR TITLE
Prepares common1.18.4

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,7 +27,7 @@ vars:
   BASEIMG: registry.hub.docker.com/{{.REPO_PATH}}
   COMMON_VER: common1.17.1
   COMMON: "{{.BASEIMG}}/openserverless-runtime-common:{{.COMMON_VER}}"
-  EXPERIMENTAL_COMMON_VER: common1.18.3
+  EXPERIMENTAL_COMMON_VER: common1.18.4
   EXPERIMENTAL_COMMON: "{{.BASEIMG}}/openserverless-runtime-common:{{.EXPERIMENTAL_COMMON_VER}}"
   TAG:
     sh: git describe --tags --abbrev=0 2>/dev/null || echo latest

--- a/openwhisk/stopHandler.go
+++ b/openwhisk/stopHandler.go
@@ -164,14 +164,14 @@ func (serverAp *ActionProxy) timedDelete(actionCodeHash string) {
 		}
 	}
 
-	Debug("Starting wait cycle for hash '%s'", actionCodeHash)
+	Debug("Starting wait cycle for stopping hash '%s'", actionCodeHash)
 	<-time.After(timerDuration)
-	Debug("Ended wait cycle for hash '%s'", actionCodeHash)
+	Debug("Ended wait cycle for stopping hash '%s'", actionCodeHash)
 
 	if len(innerAPValue.connectedActionIDs) == 0 {
 		stopAndDelete(serverAp, innerAPValue, actionCodeHash)
 		return
 	}
 
-	Debug("Skipped deletion for hash '%s' as new actions joined.", actionCodeHash)
+	Debug("Stopping request for hash '%s' skipped, as new actions joined.", actionCodeHash)
 }

--- a/proxy.go
+++ b/proxy.go
@@ -86,7 +86,6 @@ func main() {
 	if useProxyClient == "1" {
 		// hook exit signals for remote action cleanup
 		go ap.HookExitSignals()
-		openwhisk.Debug("OpenWhisk ActionLoop Proxy HookExitSignals() disabled")
 	}
 
 	// start the balls rolling

--- a/runtime/common/common1.18.4/Dockerfile
+++ b/runtime/common/common1.18.4/Dockerfile
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Do not fix the patch level for golang:1.19 to automatically get security fixes.
+FROM golang:1.21
+ENV HOME=/tmp
+USER nobody
+RUN CGO_ENABLED=0 go install github.com/apache/openserverless-runtimes@common1.18.4
+RUN mv /go/bin/openserverless-runtimes /go/bin/proxy
+ENTRYPOINT [ "/go/bin/proxy" ]

--- a/runtime/go/v1.22proxy/Dockerfile
+++ b/runtime/go/v1.22proxy/Dockerfile
@@ -19,7 +19,7 @@
 #ARG COMMON=missing:missing
 #FROM ${COMMON} AS builder
 
-FROM apache/openserverless-runtime-common:common1.18.3 AS builder
+FROM apache/openserverless-runtime-common:common1.18.4 AS builder
 
 FROM golang:1.22-bookworm
 ENV OW_EXECUTION_ENV=apacheopenserverless/runtime-golang-v1.22


### PR DESCRIPTION
This PR prepares for common1.18.4 release featuring:

- enhanced action request management in proxy server mode
- enhanced cleanup to remove dangling actions when OW runtime requests to delete code executing library setup calls.