### PR TITLE
Handle uninitialized server data in stop requests

### DIFF
--- a/openwhisk/stopHandler.go
+++ b/openwhisk/stopHandler.go
@@ -44,6 +44,12 @@ func (ap *ActionProxy) stopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if ap.serverProxyData == nil {
+		Debug("Server proxy data not initialized... a restart might have happened!")
+		sendError(w, http.StatusInternalServerError, "Server proxy data not initialized")
+		return
+	}
+
 	// parse the request
 	body, err := io.ReadAll(r.Body)
 	defer r.Body.Close()


### PR DESCRIPTION
This PR adds a fix in stop handler. When a server mode proxy crashes and restarts the server data is not set.