### PR TITLE
fix: image.yaml was containing some string coming from copy&paste?

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Assign TAG from push
         if:  ${{ github.event_name != 'pull_request' }}
         run: |
-          echo "IMG_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"registry.hub.docker.com/apache/openserverless-runtime-common:common1.17.1
+          echo "IMG_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
       - name: Use non ASF docker hub repo
         if:  ${{ github.repository_owner != 'apache'}}
         run: |


### PR DESCRIPTION
This PR fix an issue in the go based runtimes builds due to a string which seems to have been added by mistake into the TAG job, causing the job to fail.