### PR TITLE
fix: ensure GH actions relies on ubuntu-22.04

### DIFF
--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   common:
     name: Build Golang Common
-    runs-on: ubuntu-latest   
+    runs-on: ubuntu-22.04  
     steps:
       - name: Checkout recursive
         uses: actions/checkout@v2

--- a/.github/workflows/experimental.yaml
+++ b/.github/workflows/experimental.yaml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   common:
     name: Build Experimental Runtimes
-    runs-on: ubuntu-latest   
+    runs-on: ubuntu-22.04  
     steps:
       - name: Checkout recursive
         uses: actions/checkout@v2

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   golang:
     name: Build Golang
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 1
       matrix:
@@ -97,7 +97,7 @@ jobs:
   python:
       name: Build Python
       needs: golang
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       strategy:
         max-parallel: 1
         matrix:
@@ -163,7 +163,7 @@ jobs:
   nodejs:
     name: Build NodeJs
     needs: python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 1
       matrix:
@@ -229,7 +229,7 @@ jobs:
   php:
       name: Build Php
       needs: nodejs
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       strategy:
         max-parallel: 1
         matrix:
@@ -295,7 +295,7 @@ jobs:
   java:
       name: Build Java
       needs: php
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       strategy:
         max-parallel: 1
         matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
     test:
         name: Test Go Proxy
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
           - name: Checkout recursive
             uses: actions/checkout@v2


### PR DESCRIPTION
This fix ensure GH actions uses ubuntu-22.04 at using by default the ubuntu-latest version causes issues and it is nor ensuring process stability