### PR TITLE
chore: removes deprecated python build from GH image action

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -101,7 +101,7 @@ jobs:
       strategy:
         max-parallel: 1
         matrix:
-          version: [v3.10,v3.11,v3.11ca,v3.12]      
+          version: [v3.10,v3.11,v3.12]      
       steps:
         - name: Checkout recursive
           uses: actions/checkout@v2


### PR DESCRIPTION
removes deprecated python build from GH image action