### PR TITLE
chore: default go runtime

### DIFF
--- a/runtimes.json.tpl
+++ b/runtimes.json.tpl
@@ -228,7 +228,7 @@
             },
             {
                 "kind": "go:1.22proxy",
-                "default": true,
+                "default": false,
                 "deprecated": false,
                 "attached": {
                     "attachmentName": "codefile",


### PR DESCRIPTION
fixed wrong default: true in go:1.22proxy