### PR TITLE
Fix: Go runtimes librdkafka apt-get install and pin delve to v1.23.0

### DIFF
--- a/runtime/go/v1.20/Dockerfile
+++ b/runtime/go/v1.20/Dockerfile
@@ -31,13 +31,12 @@ RUN \
       jq \
       git \
       zip \
-      vim && \
-    apt-get -y install \
+      vim \
     librdkafka1 \
     librdkafka++1 \
     librdkafka-dev &&\
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    go install github.com/go-delve/delve/cmd/dlv@latest &&\
+    go install github.com/go-delve/delve/cmd/dlv@v1.23.0 &&\
     mkdir /action
 
 ADD bin/compile /bin/compile

--- a/runtime/go/v1.21/Dockerfile
+++ b/runtime/go/v1.21/Dockerfile
@@ -32,13 +32,12 @@ RUN \
      jq \
      git \
      zip \
-     vim && \
-     apt-get -y install \
+     vim \
      librdkafka1 \
      librdkafka++1 \
      librdkafka-dev &&\
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    go install github.com/go-delve/delve/cmd/dlv@latest &&\
+    go install github.com/go-delve/delve/cmd/dlv@v1.23.0 &&\
     mkdir /action
 
 ADD bin/compile /bin/compile

--- a/runtime/go/v1.22/Dockerfile
+++ b/runtime/go/v1.22/Dockerfile
@@ -32,14 +32,13 @@ RUN \
      jq \
      git \
      zip \
-     vim && \
-     apt-get -y install \
+     vim \
      librdkafka1 \
      librdkafka++1 \
      librdkafka-dev &&\
     # Cleanup apt data, we do not need them later on.
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    go install github.com/go-delve/delve/cmd/dlv@latest &&\
+    go install github.com/go-delve/delve/cmd/dlv@v1.23.0 &&\
     mkdir /action
 
 ADD bin/compile /bin/compile

--- a/runtime/go/v1.22proxy/Dockerfile
+++ b/runtime/go/v1.22proxy/Dockerfile
@@ -35,14 +35,13 @@ RUN \
     jq \
     git \
     zip \
-    vim && \
-    apt-get -y install \
+    vim \
     librdkafka1 \
     librdkafka++1 \
     librdkafka-dev &&\
     # Cleanup apt data, we do not need them later on.
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    go install github.com/go-delve/delve/cmd/dlv@latest &&\
+    go install github.com/go-delve/delve/cmd/dlv@v1.23.0 &&\
     mkdir /action
 
 ADD bin/compile /bin/compile


### PR DESCRIPTION
## Summary

Two fixes applied to all Go runtime Dockerfiles (v1.20, v1.21, v1.22, v1.22proxy).

## Fix 1 — librdkafka install fails without apt-get update

The `librdkafka` packages were installed in a second separate `apt-get install` command without a preceding `apt-get update`. On Debian Bookworm the package index is not pre-populated, causing the install to fail with 'E: Unable to locate package'.

Fix: merged the two `apt-get install` blocks into one, so `librdkafka1`, `librdkafka++1` and `librdkafka-dev` are installed in the same layer as `curl`, `jq`, `git`, `zip` and `vim`, which already runs after `apt-get update`.

## Fix 2 — delve@latest incompatible with Go 1.21

`go install github.com/go-delve/delve/cmd/dlv@latest` resolves to v1.26.3 which requires Go >= 1.24. The Go 1.21 runtime fails with:

```
github.com/go-delve/delve@v1.26.3 requires go >= 1.24 (running go 1.21.13; GOTOOLCHAIN=local)
```

Fix: pinned delve to v1.23.0, the last version compatible with Go 1.21.

## Testing

Build verified locally with:
```
docker buildx build runtime/go/v1.21/   --build-arg COMMON=registry.hub.docker.com/apache/openserverless-runtime-common:common1.17.1   --load -t test-go-runtime:local
```
Build completes successfully.